### PR TITLE
move section number checks from api layer to db layer

### DIFF
--- a/internal/api/event.go
+++ b/internal/api/event.go
@@ -492,212 +492,128 @@ func (e *env) addEventSection(c *gin.Context) {
 
 	switch *input.SectionNumber {
 	case 1:
-		section, err := e.db.GetSection1ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection1ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 1 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 2:
-		section, err := e.db.GetSection2ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection2ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 2 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 3:
-		section, err := e.db.GetSection3ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection3ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 3 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 4:
-		section, err := e.db.GetSection4ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection4ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 4 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 5:
-		section, err := e.db.GetSection5ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection5ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 5 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 6:
-		section, err := e.db.GetSection6ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection6ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 6 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 7:
-		section, err := e.db.GetSection7ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection7ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 7 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 8:
-		section, err := e.db.GetSection8ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection8ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 8 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 9:
-		section, err := e.db.GetSection9ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection9ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 9 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 10:
-		section, err := e.db.GetSection10ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection10ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 10 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 11:
-		section, err := e.db.GetSection11ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection11ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 11 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 12:
-		section, err := e.db.GetSection12ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection12ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 12 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 13:
-		section, err := e.db.GetSection13ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection13ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 13 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}
 	case 14:
-		section, err := e.db.GetSection14ByID(context.TODO(), claims.ID, input.SectionID)
+		_, err := e.db.GetSection14ByID(context.TODO(), claims.ID, input.SectionID)
 		if err != nil {
 			response := InterpretCosmosError(err)
 			c.JSON(response.Code, gin.H{
 				"message": response.Message,
-			})
-			return
-		}
-		if section.Section != 14 {
-			c.JSON(404, gin.H{
-				"message": ErrNotFound,
 			})
 			return
 		}

--- a/internal/api/resume.go
+++ b/internal/api/resume.go
@@ -147,14 +147,6 @@ func (e *env) getSection1(c *gin.Context) {
 		return
 	}
 
-	//todo: filter this in the db package
-	if output.Section.Section != 1 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	c.JSON(200, output)
 
 }
@@ -286,13 +278,6 @@ func (e *env) updateSection1(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 1 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section1{
@@ -415,13 +400,6 @@ func (e *env) getSection2(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 2 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -553,13 +531,6 @@ func (e *env) updateSection2(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 2 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section2{
@@ -680,13 +651,6 @@ func (e *env) getSection3(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 3 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -820,13 +784,6 @@ func (e *env) updateSection3(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 3 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section3{
@@ -949,13 +906,6 @@ func (e *env) getSection4(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 4 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -1089,13 +1039,6 @@ func (e *env) updateSection4(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 4 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section4{
@@ -1218,13 +1161,6 @@ func (e *env) getSection5(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 5 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -1358,13 +1294,6 @@ func (e *env) updateSection5(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 5 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section5{
@@ -1488,13 +1417,6 @@ func (e *env) getSection6(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 6 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -1629,13 +1551,6 @@ func (e *env) updateSection6(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 6 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section6{
@@ -1759,13 +1674,6 @@ func (e *env) getSection7(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 7 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -1899,13 +1807,6 @@ func (e *env) updateSection7(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 7 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section7{
@@ -2028,13 +1929,6 @@ func (e *env) getSection8(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 8 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -2168,13 +2062,6 @@ func (e *env) updateSection8(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 8 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section8{
@@ -2299,13 +2186,6 @@ func (e *env) getSection9(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 9 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -2441,13 +2321,6 @@ func (e *env) updateSection9(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 9 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section9{
@@ -2574,13 +2447,6 @@ func (e *env) getSection10(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 10 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -2716,13 +2582,6 @@ func (e *env) updateSection10(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 10 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section10{
@@ -2847,13 +2706,6 @@ func (e *env) getSection11(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 11 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -2987,13 +2839,6 @@ func (e *env) updateSection11(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 11 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section11{
@@ -3116,13 +2961,6 @@ func (e *env) getSection12(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 12 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -3256,13 +3094,6 @@ func (e *env) updateSection12(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 12 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section12{
@@ -3383,13 +3214,6 @@ func (e *env) getSection13(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 13 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -3521,13 +3345,6 @@ func (e *env) updateSection13(c *gin.Context) {
 		return
 	}
 
-	if existingSection.Section != 13 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
-		})
-		return
-	}
-
 	timestamp := utils.TimeNow()
 
 	updatedSection := db.Section13{
@@ -3645,13 +3462,6 @@ func (e *env) getSection14(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if output.Section.Section != 14 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}
@@ -3779,13 +3589,6 @@ func (e *env) updateSection14(c *gin.Context) {
 		response := InterpretCosmosError(err)
 		c.JSON(response.Code, gin.H{
 			"message": response.Message,
-		})
-		return
-	}
-
-	if existingSection.Section != 14 {
-		c.JSON(404, gin.H{
-			"message": ErrNotFound,
 		})
 		return
 	}

--- a/pkg/db/db_resume.go
+++ b/pkg/db/db_resume.go
@@ -3,7 +3,9 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 )
 
@@ -153,6 +155,13 @@ func (env *env) GetSection1ByID(ctx context.Context, userID string, sectionID st
 		return section, err
 	}
 
+	if section.Section != 1 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
+		return section, err
+	}
+
 	return section, nil
 
 }
@@ -256,6 +265,13 @@ func (env *env) GetSection2ByID(ctx context.Context, userID string, sectionID st
 
 	err = json.Unmarshal(response.Value, &section)
 	if err != nil {
+		return section, err
+	}
+
+	if section.Section != 2 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
 		return section, err
 	}
 
@@ -367,6 +383,13 @@ func (env *env) GetSection3ByID(ctx context.Context, userID string, sectionID st
 		return section, err
 	}
 
+	if section.Section != 3 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
+		return section, err
+	}
+
 	return section, nil
 
 }
@@ -475,6 +498,13 @@ func (env *env) GetSection4ByID(ctx context.Context, userID string, sectionID st
 		return section, err
 	}
 
+	if section.Section != 4 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
+		return section, err
+	}
+
 	return section, nil
 
 }
@@ -580,6 +610,13 @@ func (env *env) GetSection5ByID(ctx context.Context, userID string, sectionID st
 
 	err = json.Unmarshal(response.Value, &section)
 	if err != nil {
+		return section, err
+	}
+
+	if section.Section != 5 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
 		return section, err
 	}
 
@@ -692,6 +729,13 @@ func (env *env) GetSection6ByID(ctx context.Context, userID string, sectionID st
 		return section, err
 	}
 
+	if section.Section != 6 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
+		return section, err
+	}
+
 	return section, nil
 
 }
@@ -800,6 +844,13 @@ func (env *env) GetSection7ByID(ctx context.Context, userID string, sectionID st
 		return section, err
 	}
 
+	if section.Section != 7 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
+		return section, err
+	}
+
 	return section, nil
 
 }
@@ -905,6 +956,13 @@ func (env *env) GetSection8ByID(ctx context.Context, userID string, sectionID st
 
 	err = json.Unmarshal(response.Value, &section)
 	if err != nil {
+		return section, err
+	}
+
+	if section.Section != 8 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
 		return section, err
 	}
 
@@ -1018,6 +1076,13 @@ func (env *env) GetSection9ByID(ctx context.Context, userID string, sectionID st
 		return section, err
 	}
 
+	if section.Section != 9 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
+		return section, err
+	}
+
 	return section, nil
 
 }
@@ -1125,6 +1190,13 @@ func (env *env) GetSection10ByID(ctx context.Context, userID string, sectionID s
 
 	err = json.Unmarshal(response.Value, &section)
 	if err != nil {
+		return section, err
+	}
+
+	if section.Section != 10 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
 		return section, err
 	}
 
@@ -1236,6 +1308,13 @@ func (env *env) GetSection11ByID(ctx context.Context, userID string, sectionID s
 		return section, err
 	}
 
+	if section.Section != 11 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
+		return section, err
+	}
+
 	return section, nil
 
 }
@@ -1341,6 +1420,13 @@ func (env *env) GetSection12ByID(ctx context.Context, userID string, sectionID s
 
 	err = json.Unmarshal(response.Value, &section)
 	if err != nil {
+		return section, err
+	}
+
+	if section.Section != 12 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
 		return section, err
 	}
 
@@ -1450,6 +1536,13 @@ func (env *env) GetSection13ByID(ctx context.Context, userID string, sectionID s
 		return section, err
 	}
 
+	if section.Section != 13 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
+		return section, err
+	}
+
 	return section, nil
 
 }
@@ -1553,6 +1646,13 @@ func (env *env) GetSection14ByID(ctx context.Context, userID string, sectionID s
 
 	err = json.Unmarshal(response.Value, &section)
 	if err != nil {
+		return section, err
+	}
+
+	if section.Section != 14 {
+		err = &azcore.ResponseError{
+			StatusCode: http.StatusNotFound,
+		}
 		return section, err
 	}
 


### PR DESCRIPTION
GetSectionXByID functions in db layer could be passed IDs that did not belong to section X and if they existed as another section, the functions would return non nil and malformed sections. api layer filtered these out previously, this pr moves this filtering to the db layer (where I should've put it in the first place) and cleans up some api logic

Closes #27 